### PR TITLE
fix empty PYTHONPATH issue

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -158,3 +158,8 @@ cython_debug/
 #  and can be added to the global gitignore or merged into this file.  For a more nuclear
 #  option (not recommended) you can uncomment the following to ignore the entire idea folder.
 #.idea/
+
+# Pyenv version setting
+.python-version
+# VS Code settings
+settings.json

--- a/thonnycontrib/black_formatter/__init__.py
+++ b/thonnycontrib/black_formatter/__init__.py
@@ -1,10 +1,9 @@
+import os
 import subprocess
 import sys
-import os
-
 from collections import namedtuple
-
 from tkinter.messagebox import showinfo
+
 from thonny import get_workbench
 from thonny.running import get_front_interpreter_for_subprocess
 
@@ -45,7 +44,7 @@ class BlackFormat:
         binfolder = plugins_folder.replace("lib/python/site-packages", "bin")
 
         os.environ["PYTHONPATH"] = plugins_folder + (
-            ":" + os.environ["PYTHONPATH"] if os.environ["PYTHONPATH"] else ""
+            ":" + os.environ["PYTHONPATH"] if "PYTHONPATH" in os.environ.keys() else ""
         )
         os.environ["PATH"] = binfolder + ":" + plugins_folder + ":" + os.environ["PATH"]
 


### PR DESCRIPTION
I got an exception when accessing the `os.environ` dict because my `PYTHONPATH` was not set.
This simple change fixed it for me.

PS. Thanks for porting this to 4.x! 